### PR TITLE
Feature: Use file to specify ignored files

### DIFF
--- a/.linelint.yml
+++ b/.linelint.yml
@@ -5,6 +5,10 @@ autofix: true
 ignore:
   - .git/
 
+# uncomment this if you want to use file to list paths to ignore
+# rules will be appended to those specified in `ignore`
+# ignore-file: .gitignore
+
 rules:
   # checks if file ends in a newline character
   end-of-file:

--- a/linter/config.go
+++ b/linter/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// Ignore uses the gitignore syntax the select which files or folders to ignore
 	Ignore []string `yaml:"ignore"`
 
+	// IgnoreFile contains file, that specify files to ignore. You can add .gitignore here
+	IgnoreFile string `yaml:"ignore-file"`
+
 	// Rules contains configuration specific for each rule
 	Rules RulesConfig `yaml:"rules"`
 }

--- a/linter/config_test.go
+++ b/linter/config_test.go
@@ -20,9 +20,35 @@ rules:
     single-new-line: true
 `
 
+var yamlTestConfigWithIgnoreFile = `
+autofix: false
+
+ignore:
+  - .git/
+ignore-file: .gitignore
+
+rules:
+  end-of-file:
+    enable: true
+    disable-autofix: false
+    single-new-line: true
+`
+
 var autofixTestConf = Config{
 	AutoFix: true,
 	Ignore:  []string{".git/"},
+	Rules: RulesConfig{
+		EndOfFile: EndOfFileConfig{
+			Enable:        true,
+			SingleNewLine: true,
+		},
+	},
+}
+
+var TestConfWithIgnoreFile = Config{
+	AutoFix:    false,
+	Ignore:     []string{".git/"},
+	IgnoreFile: ".gitignore",
 	Rules: RulesConfig{
 		EndOfFile: EndOfFileConfig{
 			Enable:        true,
@@ -40,6 +66,19 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(c, NewDefaultConfig()) {
-		t.Errorf("yaml.Unmarshal(Config):\n\tExpected %+v, got %+v", autofixTestConf, c)
+		t.Errorf("yaml.Unmarshal(Config):\n\tExpected %+v, got %+v", NewDefaultConfig(), c)
+	}
+}
+
+func TestConfigWithIgnoreFile(t *testing.T) {
+	c := Config{}
+
+	err := yaml.Unmarshal([]byte(yamlTestConfigWithIgnoreFile), &c)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal(Config): %v", err)
+	}
+
+	if !reflect.DeepEqual(c, TestConfWithIgnoreFile) {
+		t.Errorf("yaml.Unmarshal(Config):\n\tExpected %+v, got %+v", TestConfWithIgnoreFile, c)
 	}
 }

--- a/linter/eof.go
+++ b/linter/eof.go
@@ -2,6 +2,8 @@ package linter
 
 import (
 	"regexp"
+
+	gitignore "github.com/sabhiram/go-gitignore"
 )
 
 // EndOfFileRule checks if the file ends in a newline character, or `\n`. It can be
@@ -22,10 +24,23 @@ func NewEndOfFileRule(config Config) Linter {
 			Name:        "EOF Rule",
 			Description: "Checks if file ends in a newline character.",
 			AutoFix:     !config.Rules.EndOfFile.DisableAutofix && config.AutoFix,
-			Ignore:      MustCompileIgnoreLines(append(config.Ignore, config.Rules.EndOfFile.Ignore...)...),
+			Ignore:      CompileIgnore(config),
 		},
 		SingleNewLine: config.Rules.EndOfFile.SingleNewLine,
 	}
+}
+
+func CompileIgnore(config Config) *gitignore.GitIgnore {
+	var compiledIgnore *gitignore.GitIgnore
+
+	ignoreLines := append(config.Ignore, config.Rules.EndOfFile.Ignore...)
+
+	if config.IgnoreFile == "" {
+		compiledIgnore = MustCompileIgnoreLines(ignoreLines...)
+	} else {
+		compiledIgnore = MustCompileIgnoreFileAndLines(config.IgnoreFile, ignoreLines...)
+	}
+	return compiledIgnore
 }
 
 // Lint implements the Lint interface

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -17,6 +17,18 @@ func MustCompileIgnoreLines(lines ...string) *gitignore.GitIgnore {
 	return g
 }
 
+// MustCompileIgnoreFileAndLines parses and compiles ignore file, then compiles the ignore lines
+// and throws a panic if it fails
+func MustCompileIgnoreFileAndLines(fpath string, lines ...string) *gitignore.GitIgnore {
+	g, err := gitignore.CompileIgnoreFileAndLines(fpath, lines...)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return g
+}
+
 // Linter exposes the lint method
 type Linter interface {
 	GetName() string


### PR DESCRIPTION
Hi, Fernando.
Thank you for this linter.

I don't want to check ending lines of all the files, that are gitignored.
On CI we don't have them, because they are not in the repo, but if I want to use this tool locally before push, I have to specify all those files in `ignore` list, which is annoying.

So I added an extra settings key `ignore-file`, where I can specify my `.gitignore` file and it will append all the ignore rules from there to `ignore` list.

What do you think about this PR (and feature in general)?
