### PR TITLE
chore: update `actions/checkout` to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: Check if all files end in newline
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Linelint
         uses: fernandrone/linelint@master
         id: linelint

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ jobs:
     name: Check if all files end in newline
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Linelint
         uses: actions/linelint@master
         id: linelint


### PR DESCRIPTION
This is the latest major version which I think is good to suggest to people rather than the old v2 major